### PR TITLE
Method for getting excursions created by the user

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -78,10 +78,12 @@ namespace backend.Controllers
                     if (roles != null && roles.Any())
                     {
                         var iwtToken = tokenRepository.CreateJWTToken(user, roles.ToList());
+                        var role = roles.FirstOrDefault();
 
                         var response = new LoginResponseDTO
                         {
                             JwtToken = iwtToken,
+                            Role = role
                         };
 
                         return Ok(response);

--- a/backend/Controllers/ExcursionsController.cs
+++ b/backend/Controllers/ExcursionsController.cs
@@ -121,5 +121,22 @@ namespace backend.Controllers
             }
             return Ok(excursionDTO);
         }
+
+        [HttpGet]
+        [Route("user-excursions")]
+        public async Task<IActionResult> GetUserExcursions()
+        {
+            var authHeader = Request.Headers["Authorization"].ToString();
+            var token = authHeader.StartsWith("Bearer ") ? authHeader["Bearer ".Length..].Trim() : string.Empty;
+            var userId = tokenService.GetUserIdFromToken(token);
+
+            if (userId == null)
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var excursions = await excursionRepository.GetByUserIdAsync(userId);
+            return Ok(mapper.Map<List<ExcursionDTO>>(excursions));
+        }
     }
 }

--- a/backend/Controllers/ExcursionsController.cs
+++ b/backend/Controllers/ExcursionsController.cs
@@ -68,7 +68,7 @@ namespace backend.Controllers
 
 
         /// <summary>
-        /// Creates a new excursion. Requires authentication.
+        /// Creates a new excursion. Requires authentication
         /// </summary>
         [HttpPost]
         [ValidateModel]
@@ -86,7 +86,7 @@ namespace backend.Controllers
 
 
         /// <summary>
-        /// Delete an excursion by ID. Requires authentication.
+        /// Delete an excursion by ID. Requires authentication
         /// </summary>
         [HttpDelete]
         [Route("{id:int}")]
@@ -102,7 +102,7 @@ namespace backend.Controllers
 
 
         /// <summary>
-        /// Update an existing excursion. Requires authentication.
+        /// Update an existing excursion. Requires authentication
         /// </summary>
         [HttpPatch]
         [Route("{id:int}")]
@@ -122,8 +122,13 @@ namespace backend.Controllers
             return Ok(excursionDTO);
         }
 
+
+        /// <summary>
+        /// Retrieves a list of excursions for the currently authenticated user
+        /// </summary>
         [HttpGet]
         [Route("user-excursions")]
+        [Authorize(AuthenticationSchemes = "Bearer")]
         public async Task<IActionResult> GetUserExcursions()
         {
             var authHeader = Request.Headers["Authorization"].ToString();

--- a/backend/Migrations/20241211161348_Remove column Status.Designer.cs
+++ b/backend/Migrations/20241211161348_Remove column Status.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using backend.Data;
 
@@ -11,9 +12,11 @@ using backend.Data;
 namespace backend.Migrations
 {
     [DbContext(typeof(ExcursionDbContext))]
-    partial class ExcursionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241211161348_Remove column Status")]
+    partial class RemovecolumnStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20241211161348_Remove column Status.cs
+++ b/backend/Migrations/20241211161348_Remove column Status.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovecolumnStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Excursions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Excursions",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/backend/Models/DTO/ExcursionDetailsDTO.cs
+++ b/backend/Models/DTO/ExcursionDetailsDTO.cs
@@ -12,6 +12,7 @@ namespace backend.Models.DTO
         public DateTime Date { get; set; }
         public int Price { get; set; }
         public int MaxParticipants { get; set; }
+        public int CurrentParticipants { get; set; }
         public string? Photo { get; set; }
     }
 }

--- a/backend/Models/DTO/LoginResponseDTO.cs
+++ b/backend/Models/DTO/LoginResponseDTO.cs
@@ -3,5 +3,6 @@
     public class LoginResponseDTO
     {
         public string JwtToken { get; set; }
+        public string Role {  get; set; }
     }
 }

--- a/backend/Models/Domain/Excursion.cs
+++ b/backend/Models/Domain/Excursion.cs
@@ -12,7 +12,6 @@
         public int MaxParticipants { get; set; }
         public int CurrentParticipants { get; set; }
         public byte[]? Photo { get; set; }
-        public string? Status { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime? UpdatedAt { get; set; }
         public int? Likes { get; set; }

--- a/backend/Repositories/IExcursionRepository.cs
+++ b/backend/Repositories/IExcursionRepository.cs
@@ -11,5 +11,6 @@ namespace backend.Repositories
         Task<Excursion?> DeleteAsync(int id);
         Task<Excursion?> UpdateAsync(int id, EditExcursionDTO editExcursionDTO);
         Task<bool> IsUserOwnerAsync(int excursionId, string userId);
+        Task<List<Excursion>> GetByUserIdAsync(string userId);
     }
 }

--- a/backend/Repositories/SQLExcursionRepository.cs
+++ b/backend/Repositories/SQLExcursionRepository.cs
@@ -94,6 +94,11 @@ namespace backend.Repositories
             return await excursionDbContext.Excursions.FirstOrDefaultAsync(e => e.Id == id);
         }
 
+        public async Task<List<Excursion>> GetByUserIdAsync(string userId)
+        {
+            return await excursionDbContext.Excursions.Where(e => e.UserId == userId).ToListAsync();
+        }
+
         public async Task<bool> IsUserOwnerAsync(int excursionId, string userId)
         {
             var excursion = await excursionDbContext.Excursions.FirstOrDefaultAsync(e => e.Id == excursionId);

--- a/backend/Repositories/SQLExcursionRepository.cs
+++ b/backend/Repositories/SQLExcursionRepository.cs
@@ -27,7 +27,6 @@ namespace backend.Repositories
             var excursion = mapper.Map<Excursion>(addExcursionDTO);
 
             excursion.UserId = userId;
-            excursion.Status = "Active";
 
             if (addExcursionDTO.Photo != null)
             {

--- a/backend/Repositories/TokenRepository.cs
+++ b/backend/Repositories/TokenRepository.cs
@@ -20,9 +20,10 @@ namespace backend.Repositories
         {
             var claims = new List<Claim>();
 
-            claims.Add(new Claim(ClaimTypes.Email, user.Email));
+            claims.Add(new Claim("email", user.Email));
             claims.Add(new Claim(JwtRegisteredClaimNames.Sub, user.Id)); 
-            claims.Add(new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())); 
+            claims.Add(new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()));
+            claims.Add(new Claim("role", roles.FirstOrDefault() ?? "User"));
 
             foreach (var role in roles)
             {


### PR DESCRIPTION
- **new method**. It's will return the list of excursions created by the user. His ID will be automatically taken from the token and his excursions will be displayed
- **changes in DB**. Removed the "Status" column from the "Excursions" table. To apply the changes locally, run the command
`Update-Database`
- **changes in login**. Now, during login, the client also gets back the user role in addition to the token itself